### PR TITLE
feat: Add unified options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Prop Name | Type | Default | Description
 `hideOnOut` | `boolean` | `false` | Determines if the custom cursor should be hidden when the cursor leaves the viewport
 `contentPosition` | `string` | `center` | Determines the position of `contents` slot relative to the cursor. Possible values are `center`, `bottom`, `right`
 `lerp` | `number` | `1` | [Linear Interpolation Value](https://codepen.io/ma77os/pen/KGIEh)
+`options` | `Object` | `{}` | All of other options in one single object. Will gracefully fallback if some values are not provided.
 
 ## Slots
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@namchee/tetikus",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@namchee/tetikus",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@namchee/tetikus",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namchee/tetikus",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A custom cursor component for Vue 3 ✌️",
   "author": "Cristopher Namchee <cristophernamchee12@gmail.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "lint": "eslint",
     "build": "rm -rf dist/ && rollup -c",
     "build:watch": "npm run build -- --watch",
-    "build:verbose": "npm run build -- --verbose",
     "test": "ava",
     "postuninstall": "npm prune"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namchee/tetikus",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A custom cursor component for Vue 3 ✌️",
   "author": "Cristopher Namchee <cristophernamchee12@gmail.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namchee/tetikus",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A custom cursor component for Vue 3 ✌️",
   "author": "Cristopher Namchee <cristophernamchee12@gmail.com>",
   "scripts": {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,8 +1,11 @@
+// Exception level to be thrown.
+// Internal usage
 export enum ExceptionLevel {
   WARNING = 1,
   ERROR = 2,
 }
 
+// Options to be passed on `app.use()` calls
 export interface ConstructorOptions {
   directiveName?: string;
   transitionSpeed?: number;
@@ -10,6 +13,9 @@ export interface ConstructorOptions {
   delay?: number;
 }
 
+// Options to be passed on props change
+// Example: color: { value: black }, then tetikus background
+// will be changed to black
 export interface TransformOpts<T> {
   value: T;
   duration?: number;
@@ -17,6 +23,7 @@ export interface TransformOpts<T> {
   easing?: string;
 }
 
+// Options to be passed on click or hover events.
 export interface TransformProps {
   id?: string | string[];
   scale?: TransformOpts<number> | number;
@@ -26,16 +33,41 @@ export interface TransformProps {
   opacity?: TransformOpts<number> | number;
 }
 
+// Internal usage
 export interface CSSStyles {
   [key: string]: string | number;
 }
 
+// Internal usage
 export interface CSSAnimation {
   cssStyles: CSSStyles;
   transitionString: string;
 }
 
+// Expected behavior from domElement on hover interaction
 export interface HoverBehavior {
   domElement: HTMLElement;
   transformProps: TransformProps;
+}
+
+// Unified tetikus props
+// Useful to avoid apropcalypse
+export interface TetikusProps {
+  showDefaultCursor?: boolean;
+  throttleSpeed?: number;
+  borderWidth?: number;
+  color?: string;
+  borderColor?: string;
+  size?: number;
+  inverColor?: boolean;
+  buttonMap?: string[];
+  clickBehavior?: TransformProps;
+  showOnTouch?: boolean;
+  opacity?: number;
+  hideOnOut?: boolean;
+  contentPosition?: string;
+  lerp?: number;
+  defaultTransitionSpeed?: number;
+  defaultEasing?: string;
+  defaultDelay?: number;
 }


### PR DESCRIPTION
## Overview

### Features

1. Adds a new property to `Tetikus` component: `options`, which is just a wrapper for a unified property object. Useful to prevent code smells and [apropcalypse](https://sid.st/post/apropcalypse/).

### Fixes

1. Fixes an issue where CSS transformations will log a warning when `id` is provided. `id` property should be ignored by transformation function. 